### PR TITLE
Update to Fable.Core 3

### DIFF
--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -64,7 +64,7 @@ open Elmish.React
 open Elmish.HMR // See how this is the last open statement
 
 Program.mkProgram init update view
-|> Program.withReact "elmish-app"
+|> Program.withReactSynchronous "elmish-app"
 |> Program.run
 
 (**
@@ -74,5 +74,5 @@ You can also use `Elmish.Program.runWith` if you need to pass custom arguments, 
 *)
 
 Program.mkProgram init update view
-|> Program.withReact "elmish-app"
+|> Program.withReactSynchronous "elmish-app"
 |> Program.runWith ("custom argument", 42)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,13 +1,8 @@
 source https://nuget.org/api/v2
 
-nuget Fable.Elmish.React
-nuget Fable.React
 nuget FSharp.Core  redirects:force, content:none
-nuget Fable.Core
-nuget Fable.Elmish
-nuget Fable.Import.HMR
-nuget Fable.Elmish.Browser
-nuget Fable.Elmish.React 2.1.0
+nuget Fable.Elmish.Browser prerelease
+nuget Fable.Elmish.React prerelease
 
 group Formatting
     source https://nuget.org/api/v2

--- a/paket.lock
+++ b/paket.lock
@@ -1,36 +1,41 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    Fable.Core (2.0.1)
+    Fable.Browser.Blob (1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish (2.0.3)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (1.0.0-alpha-004) - restriction: >= netstandard2.0
+      Fable.Browser.Blob (>= 1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Browser.Event (>= 1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Browser.WebStorage (>= 1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.Browser (2.1)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
+    Fable.Browser.Event (1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.React (2.1)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.React (>= 4.0.1) - restriction: >= netstandard2.0
+    Fable.Browser.WebStorage (1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Browser.Event (>= 1.0.0-alpha-001) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Import.Browser (1.3) - restriction: >= netstandard2.0
-      Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
-    Fable.Import.HMR (0.1)
-      Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
-    Fable.PowerPack (2.0.2) - restriction: >= netstandard2.0
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
+    Fable.Core (3.0.0-beta-005) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-      Thoth.Json (>= 2.0) - restriction: >= netstandard2.0
-    Fable.React (4.1.3)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
+    Fable.Elmish (3.0.0-beta-5) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.0.0-beta-004) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+    Fable.Elmish.Browser (3.0.0-beta-2)
+      Fable.Browser.Dom (>= 1.0.0-alpha-003) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.0.0-beta-004) - restriction: >= netstandard2.0
+      Fable.Elmish (>= 3.0.0-beta-4) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+    Fable.Elmish.React (3.0.0-beta-2)
+      Fable.Core (>= 3.0.0-beta-004) - restriction: >= netstandard2.0
+      Fable.Elmish (>= 3.0.0-beta-4) - restriction: >= netstandard2.0
+      Fable.React (>= 5.0.0-alpha-005) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+    Fable.React (5.0.0-alpha-005) - restriction: >= netstandard2.0
+      Fable.Browser.Dom (>= 1.0.0-alpha-003) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.1.0-alpha-002) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    FSharp.Core (4.5.2) - content: none, redirects: force
+    FSharp.Core (4.6.2) - content: none, redirects: force
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Console (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
@@ -54,8 +59,8 @@ NUGET
       System.Threading.Thread (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Threading.ThreadPool (>= 4.0.10) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Threading.Timer (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-    Microsoft.NETCore.Platforms (2.1.2) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
-    Microsoft.NETCore.Targets (2.1) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+    Microsoft.NETCore.Platforms (2.2) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+    Microsoft.NETCore.Targets (2.1) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
     runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
     runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
     runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
@@ -300,13 +305,13 @@ NUGET
       System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime (4.3) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.Extensions (4.3) - content: none, redirects: force, restriction: || (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
+    System.Runtime (4.3.1) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
+      Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
+    System.Runtime.Extensions (4.3.1) - content: none, redirects: force, restriction: || (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
+      Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
+      System.Runtime (>= 4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
     System.Runtime.Handles (4.3) - content: none, redirects: force, restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -376,7 +381,7 @@ NUGET
       System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+    System.Security.Cryptography.OpenSsl (4.5.1) - content: none, redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
       System.Collections (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
       System.IO (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
@@ -459,9 +464,6 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
-    Thoth.Json (2.5) - restriction: >= netstandard2.0
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
 
 GROUP FakeBuild
 STORAGE: NONE

--- a/src/Fable.Elmish.HMR.fsproj
+++ b/src/Fable.Elmish.HMR.fsproj
@@ -3,6 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="bindings.fs" />
     <Compile Include="common.fs" />
     <Compile Include="hmr.fs" />
   </ItemGroup>

--- a/src/bindings.fs
+++ b/src/bindings.fs
@@ -1,0 +1,199 @@
+module HMR
+
+open Fable.Core
+
+[<StringEnum>]
+type Status =
+    /// The process is waiting for a call to check (see below)
+    | [<CompiledName("idle")>] Idle
+    /// The process is checking for updates
+    | [<CompiledName("check")>] Check
+    /// The process is getting ready for the update (e.g. downloading the updated module)
+    | [<CompiledName("prepare")>] Prepare
+    /// The update is prepared and available
+    | [<CompiledName("ready")>] Ready
+    /// The process is calling the dispose handlers on the modules that will be replaced
+    | [<CompiledName("dispose")>] Dispose
+    /// The process is calling the accept handlers and re-executing self-accepted modules
+    | [<CompiledName("apply")>] Apply
+    /// An update was aborted, but the system is still in it's previous state
+    | [<CompiledName("abort")>] Abort
+    /// An update has thrown an exception and the system's state has been compromised
+    | [<CompiledName("fail")>] Fail
+
+type ApplyOptions =
+    /// Ignore changes made to unaccepted modules.
+    abstract ignoreUnaccepted : bool option with get, set
+    /// Ignore changes made to declined modules.
+    abstract ignoreDeclined : bool option with get, set
+    /// Ignore errors throw in accept handlers, error handlers and while reevaluating module.
+    abstract ignoreErrored : bool option with get, set
+    /// Notifier for declined modules
+    abstract onDeclined : (obj -> unit) option with get, set
+    /// Notifier for unaccepted modules
+    abstract onUnaccepted : (obj -> unit) option with get, set
+    /// Notifier for accepted modules
+    abstract onAccepted : (obj -> unit) option with get, set
+    /// Notifier for disposed modules
+    abstract onDisposed : (obj -> unit) option with get, set
+    /// Notifier for errors
+    abstract onErrored : (obj -> unit) option with get, set
+
+
+[<AllowNullLiteral>]
+type IHot =
+
+    /// **Description**
+    /// Retrieve the current status of the hot module replacement process.
+    /// **Parameters**
+    ///
+    ///
+    /// **Output Type**
+    ///   * `Status`
+    ///
+    /// **Exceptions**
+    ///
+    abstract status: unit -> Status
+
+    /// **Description**
+    /// Accept updates for the given dependencies and fire a callback to react to those updates.
+    /// **Parameters**
+    ///   * `dependencies` - parameter of type `U2<string list,string>` - Either a string or an array of strings
+    ///   * `errorHandler` - parameter of type `(obj -> unit) option` - Function to fire when the dependencies are updated
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract accept: dependencies:  U2<string list, string> * ?errorHandler: (obj -> unit) -> unit
+
+    /// **Description**
+    /// Accept updates for itself.
+    /// **Parameters**
+    ///   * `errorHandler` - parameter of type `(obj -> unit) option` - Function to fire when the dependencies are updated
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract accept: ?errorHandler: (obj -> unit) -> unit
+
+    /// **Description**
+    /// Reject updates for the given dependencies forcing the update to fail with a 'decline' code.
+    /// **Parameters**
+    ///   * `dependencies` - parameter of type `U2<string list,string>` - Either a string or an array of strings
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract decline: dependencies:  U2<string list, string> -> unit
+
+    /// **Description**
+    /// Reject updates for itself.
+    /// **Parameters**
+    ///
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract decline: unit -> unit
+
+    /// **Description**
+    /// Add a handler which is executed when the current module code is replaced.
+    /// This should be used to remove any persistent resource you have claimed or created.
+    /// If you want to transfer state to the updated module, add it to given `data` parameter.
+    /// This object will be available at `module.hot.data` after the update.
+    /// **Parameters**
+    ///   * `data` - parameter of type `obj`
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract dispose: data: obj -> unit
+
+    /// **Description**
+    /// Add a handler which is executed when the current module code is replaced.
+    /// This should be used to remove any persistent resource you have claimed or created.
+    /// If you want to transfer state to the updated module, add it to given `data` parameter.
+    /// This object will be available at `module.hot.data` after the update.
+    /// **Parameters**
+    ///   * `handler` - parameter of type `obj -> unit`
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract addDisposeHandler: handler: (obj -> unit) -> unit
+
+    /// **Description**
+    /// Remove the callback added via `dispose` or `addDisposeHandler`.
+    /// **Parameters**
+    ///   * `callback` - parameter of type `obj -> unit`
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract removeDisposeHandler: callback: (obj -> unit) -> unit
+
+    /// **Description**
+    /// Test all loaded modules for updates and, if updates exist, `apply` them.
+    /// **Parameters**
+    ///   * `autoApply` - parameter of type `U2<bool,ApplyOptions>`
+    ///
+    /// **Output Type**
+    ///   * `JS.Promise<obj>`
+    ///
+    /// **Exceptions**
+    ///
+    abstract check: autoApply: U2<bool, ApplyOptions> -> JS.Promise<obj>
+
+    /// **Description**
+    /// Continue the update process (as long as `module.hot.status() === 'ready'`).
+    /// **Parameters**
+    ///   * `options` - parameter of type `U2<bool,ApplyOptions>`
+    ///
+    /// **Output Type**
+    ///   * `JS.Promise<obj>`
+    ///
+    /// **Exceptions**
+    ///
+    abstract apply: options : ApplyOptions -> JS.Promise<obj>
+
+    /// **Description**
+    /// Register a function to listen for changes in `status`.
+    /// **Parameters**
+    ///
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract addStatusHandler: (obj -> unit) -> unit
+
+    /// **Description**
+    /// Remove a registered status handler.
+    /// **Parameters**
+    ///   * `callback` - parameter of type `obj -> unit`
+    ///
+    /// **Output Type**
+    ///   * `unit`
+    ///
+    /// **Exceptions**
+    ///
+    abstract removeStatusHandler: callback: (obj -> unit) -> unit
+
+type IModule =
+    abstract hot: IHot with get, set
+
+let [<Global>] [<Emit("module")>] ``module`` : IModule = jsNative

--- a/src/common.fs
+++ b/src/common.fs
@@ -1,10 +1,9 @@
 namespace Elmish.HMR
 
-open Fable.Import.React
-open Elmish
-open Fable.Import
 open Fable.Core.JsInterop
-open Fable.Helpers.React
+open Fable.React
+open Browser
+open Elmish
 
 [<AutoOpen>]
 module Common =
@@ -23,10 +22,10 @@ module Common =
             inherit Component<LazyProps<'model>,LazyState>(props)
 
             let hmrCount =
-                if isNull Browser.window?Elmish_HMR_Count then
+                if isNull window?Elmish_HMR_Count then
                     0
                 else
-                    unbox<int> Browser.window?Elmish_HMR_Count
+                    unbox<int> window?Elmish_HMR_Count
 
             do base.setInitState({ HMRCount = hmrCount})
 
@@ -36,7 +35,7 @@ module Common =
                 if isNull hot then
                     not <| this.props.equal this.props.model nextProps.model
                 else
-                    let currentHmrCount : int = Browser.window?Elmish_HMR_Count
+                    let currentHmrCount : int = window?Elmish_HMR_Count
                     if currentHmrCount > this.state.HMRCount then
                         this.setState(fun _prevState _props ->
                             { HMRCount = currentHmrCount }

--- a/src/hmr.fs
+++ b/src/hmr.fs
@@ -1,28 +1,27 @@
 namespace Elmish.HMR
 
+open Fable.Core.JsInterop
+open Browser
 open Elmish
 open Elmish.Browser
-open Fable.Import
-open Fable.Import.Browser
-open Fable.Core.JsInterop
 
 [<RequireQualifiedAccess>]
 module Program =
 
-    module Internal =
-        type Plateform =
+    module private Internal =
+        type Platform =
             | Browser
             | ReactNative
 
-        let plateform =
-            match Browser.window.navigator.product with
+        let platform =
+            match window?navigator?product with
             | "ReactNative" -> ReactNative
             | _ -> Browser
 
         let tryRestoreState (hot : HMR.IHot) =
-            match plateform with
+            match platform with
             | ReactNative ->
-                let hmrState = Browser.window?react_native_elmish_hmr_state
+                let hmrState = window?react_native_elmish_hmr_state
                 if not (isNull hmrState) then
                     Some hmrState
                 else
@@ -35,9 +34,9 @@ module Program =
                     None
 
         let saveState (data : obj) (hmrState : obj) =
-            match plateform with
+            match platform with
             | ReactNative ->
-                Browser.window?react_native_elmish_hmr_state <- hmrState
+                window?react_native_elmish_hmr_state <- hmrState
             | Browser ->
                 data?hmrState <- hmrState
 
@@ -51,16 +50,16 @@ module Program =
 
     #if DEBUG
     /// Start the dispatch loop with `'arg` for the init() function.
-    let inline runWith (arg: 'arg) (program: Program<'arg, 'model, 'msg, 'view>) =
+    let runWith (arg: 'arg) (program: Program<'arg, 'model, 'msg, 'view>) =
         let mutable hmrState : obj = null
         let hot = HMR.``module``.hot
 
         if not (isNull hot) then
-            Browser.window?Elmish_HMR_Count <-
-                if isNull Browser.window?Elmish_HMR_Count then
+            window?Elmish_HMR_Count <-
+                if isNull window?Elmish_HMR_Count then
                     0
                 else
-                    Browser.window?Elmish_HMR_Count + 1
+                    window?Elmish_HMR_Count + 1
 
             hot.accept() |> ignore
 
@@ -159,23 +158,19 @@ You should not see this message
           subscribe = subs
           onError = program.onError
           setState = setState
-          view = view }
+          view = view
+          syncDispatch = id }
 
         |> Elmish.Program.runWith arg
-    #else
-    let inline runWith (arg: 'arg) (program: Program<'arg, 'model, 'msg, 'view>) =
-        Elmish.Program.runWith arg program
-    #endif
 
     /// Start the dispatch loop with `unit` for the init() function.
-    let inline run (program: Program<unit, 'model, 'msg, 'view>) =
+    let run (program: Program<unit, 'model, 'msg, 'view>) =
         runWith () program
 
     (*
         Shadow: Fable.Elmish.Navigation
     *)
 
-    #if DEBUG
     let toNavigable
         (parser : Navigation.Parser<'a>)
         (urlUpdate : 'a->'model->('model * Cmd<'msg>))
@@ -189,47 +184,25 @@ You should not see this message
             Navigation.Program.Internal.subscribe dispatch
 
         Navigation.Program.Internal.toNavigableWith parser urlUpdate program onLocationChange
-    #else
-    let inline toNavigable
-        (parser : Navigation.Parser<'a>)
-        (urlUpdate : 'a->'model->('model * Cmd<'msg>))
-        (program : Program<'a,'model,'msg,'view>) =
-
-            Navigation.Program.toNavigable parser urlUpdate program
-    #endif
 
     (*
         Shadow: Fable.Elmish.React
     *)
 
-    #if DEBUG
-    /// Setup rendering of root React component inside html element identified by placeholderId
-    let inline withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Elmish.React.Program.Internal.withReactUsing lazyView2With placeholderId program
-    #else
-    /// Setup rendering of root React component inside html element identified by placeholderId
-    let inline withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Elmish.React.Program.withReact placeholderId program
-    #endif
+    let withReactBatched placeholderId (program:Elmish.Program<_,_,_,_>) =
+        Elmish.React.Program.Internal.withReactBatchedUsing lazyView2With placeholderId program
 
-    #if DEBUG
-    /// `withReact` uses `requestAnimationFrame` to optimize rendering in scenarios with updates at a higher rate than 60FPS, but this makes the cursor jump to the end in `input` elements.
-    /// This function works around the glitch if you don't need the optimization (see https://github.com/elmish/react/issues/12).
-    let inline withReactUnoptimized placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Elmish.React.Program.Internal.withReactUnoptimizedUsing lazyView2With placeholderId program
-    #else
-    /// `withReact` uses `requestAnimationFrame` to optimize rendering in scenarios with updates at a higher rate than 60FPS, but this makes the cursor jump to the end in `input` elements.
-    /// This function works around the glitch if you don't need the optimization (see https://github.com/elmish/react/issues/12).
-    let inline withReactUnoptimized placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Elmish.React.Program.withReactUnoptimized placeholderId program
-    #endif
+    let withReactSynchronous placeholderId (program:Elmish.Program<_,_,_,_>) =
+        Elmish.React.Program.Internal.withReactSynchronousUsing lazyView2With placeholderId program
 
-    #if DEBUG
-    /// Setup rendering of root React component inside html element identified by placeholderId using React.hydrate
-    let inline withReactHydrate placeholderId (program:Elmish.Program<_,_,_,_>) =
+    let withReactHydrate placeholderId (program:Elmish.Program<_,_,_,_>) =
         Elmish.React.Program.Internal.withReactHydrateUsing lazyView2With placeholderId program
-    #else
-    /// Setup rendering of root React component inside html element identified by placeholderId using React.hydrate
-    let inline withReactHydrate placeholderId (program:Elmish.Program<_,_,_,_>) =
-        Elmish.React.Program.withReactHydrate placeholderId program
+
+    [<System.Obsolete("Use withReactBatched")>]
+    let withReact placeholderId (program:Elmish.Program<_,_,_,_>) =
+        Elmish.React.Program.Internal.withReactBatchedUsing lazyView2With placeholderId program
+
+    [<System.Obsolete("Use withReactSynchronous")>]
+    let withReactUnoptimized placeholderId (program:Elmish.Program<_,_,_,_>) =
+        Elmish.React.Program.Internal.withReactSynchronousUsing lazyView2With placeholderId program
     #endif

--- a/src/paket.references
+++ b/src/paket.references
@@ -1,7 +1,4 @@
 FSharp.Core
 Fable.Core
-Fable.Elmish
-Fable.Import.HMR
 Fable.Elmish.Browser
-Fable.React
 Fable.Elmish.React


### PR DESCRIPTION
This PR:

- Makes Elmish.HMR compatible with Fable.Core 3
- Because the idea is to deprecate the Fable.Import packages, for now I've just copied the HMR bindings directly to remove the Fable.Import.HMR dependency
- I've removed the `#else .. #endif` alternatives. In production the app should just default to Elmish.Program methods
- Is it correct to just use `id` for `syncDispatch` field?