### PR TITLE
Add comment to import.meta.hot #35

### DIFF
--- a/src/HMR.Webpack.fs
+++ b/src/HMR.Webpack.fs
@@ -203,8 +203,8 @@ type IHot =
 // `import.meta.webpackHot` the HMR support will be done indirectly via HMR.Parcel module
 // This is to try keep a clean written and generated code
 
-[<Emit("import.meta.webpackHot")>]
+[<Emit("(import.meta.hot /* If error see https://github.com/elmish/hmr/issues/35 */)")>]
 let hot : IHot = jsNative
 
-[<Emit("import.meta.webpackHot")>]
+[<Emit("(import.meta.hot /* If error see https://github.com/elmish/hmr/issues/35 */)")>]
 let active : bool = jsNative


### PR DESCRIPTION
I didn't add it to all the emits in `HMR.Vite.fs`. Is there a reason it's not just a single emit over `let hot = ...` like in `HMR.Webpack.fs`?