### PR TITLE
Inactive programs shouldn't save hmrState

### DIFF
--- a/src/hmr.fs
+++ b/src/hmr.fs
@@ -88,17 +88,17 @@ module Program =
 
         let mapUpdate update (msg : Msg<'msg>) (model : Model<'model>) =
             match msg with
-                | UserMsg msg ->
-                    match model with
-                    | Inactive -> map(model, Cmd.none)
-                    | Active userModel ->
-                        let newModel, cmd = update msg userModel
-                        let newModel, cmd = map(Active newModel, cmd)
-                        hmrState.Value <- newModel
-                        newModel, cmd
+            | UserMsg msg ->
+                match model with
+                | Inactive -> map(model, Cmd.none)
+                | Active userModel ->
+                    let newModel, cmd = update msg userModel
+                    let newModel, cmd = map(Active newModel, cmd)
+                    hmrState.Value <- newModel
+                    newModel, cmd
 
-                | Stop ->
-                    map(Inactive, Cmd.none)
+            | Stop ->
+                map(Inactive, Cmd.none)
 
         let createModel (model, cmd) =
             Active model, cmd

--- a/src/hmr.fs
+++ b/src/hmr.fs
@@ -87,22 +87,18 @@ module Program =
             model, cmd |> Cmd.map UserMsg
 
         let mapUpdate update (msg : Msg<'msg>) (model : Model<'model>) =
-            let newModel,cmd =
-                match msg with
-                    | UserMsg msg ->
-                        match model with
-                        | Inactive -> model, Cmd.none
-                        | Active userModel ->
-                            let newModel, cmd = update msg userModel
-                            Active newModel, cmd
+            match msg with
+                | UserMsg msg ->
+                    match model with
+                    | Inactive -> map(model, Cmd.none)
+                    | Active userModel ->
+                        let newModel, cmd = update msg userModel
+                        let newModel, cmd = map(Active newModel, cmd)
+                        hmrState.Value <- newModel
+                        newModel, cmd
 
-                    | Stop ->
-                        Inactive, Cmd.none
-                    |> map
-
-            hmrState.Value <- newModel
-
-            newModel,cmd
+                | Stop ->
+                    map(Inactive, Cmd.none)
 
         let createModel (model, cmd) =
             Active model, cmd


### PR DESCRIPTION
Not entirely sure why this hasn't surfaced before and why it's happening now to me (using Vite), but it looks in some situations the `hot.dispose` runs a bit late and, because `mapUpdate` replaces hmrState no matter whether the program is active or not, in the next update the `Inactive` state is loaded and Elmish _freezes_.

Only saving hmrState for active programs seem to fix this.