### PR TITLE
Clarify inline only for old webpack.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ paket add nuget Fable.Elmish.HMR
 
 ## Webpack configuration
 
-Add `hot: true` and `inline: true` to your `devServer` node.
+Add `hot: true` and `inline: true` (only for webpack < v5.0.0) to your `devServer` node.
 
 Example:
 


### PR DESCRIPTION
This updates a small portion of the documentation.
The `inline` property has been removed from webpack >=v5.