### PR TITLE
update for 5.5.0-beta-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,10 @@ jobs:
         run: dotnet tool restore
       - name: Build package
         run: dotnet build src
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    matrix:
-      os: [ ubuntu-latest, macOS-latest, windows-latest ]
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
                 "changelog-parser": "^2.8.1",
                 "concurrently": "^7.5.0",
                 "gatsby-remark-vscode": "^3.3.1",
+                "global-jsdom": "^9.0.0",
                 "html-webpack-plugin": "^5.5.0",
+                "jsdom": "^23.0.0",
+                "mocha": "^10.8.2",
                 "nacara": "^1.7.0",
                 "nacara-layout-standard": "^1.8.0",
                 "parcel": "^2.8.0",
@@ -47,6 +50,60 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+            "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bidi-js": "^1.0.3",
+                "css-tree": "^2.3.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -73,7 +130,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
             "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -531,6 +587,121 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -991,7 +1162,6 @@
             "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
             "integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.0",
                 "@parcel/cache": "2.8.0",
@@ -2273,8 +2443,7 @@
             "version": "18.11.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
             "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.0",
@@ -2573,7 +2742,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
             "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2590,12 +2758,21 @@
                 "acorn": "^8"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2653,6 +2830,16 @@
             "dev": true,
             "peerDependencies": {
                 "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/ansi-html-community": {
@@ -2718,6 +2905,13 @@
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
             "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
             "dev": true
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/bail": {
             "version": "2.0.2",
@@ -2808,6 +3002,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/binary-extensions": {
@@ -2917,6 +3121,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/browserslist": {
             "version": "4.21.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
@@ -2932,7 +3143,6 @@
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -3036,6 +3246,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3053,6 +3277,19 @@
             "dependencies": {
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/caniuse-lite": {
@@ -3254,6 +3491,19 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
             "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.2",
@@ -3532,6 +3782,41 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cssstyle/node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/date-fns": {
             "version": "2.29.3",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -3546,12 +3831,13 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -3561,6 +3847,26 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.0.2",
@@ -3692,6 +3998,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3739,10 +4055,11 @@
             "dev": true
         },
         "node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -3876,6 +4193,21 @@
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3958,11 +4290,60 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
             "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/esbuild": {
             "version": "0.15.12",
@@ -4650,6 +5031,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -4668,6 +5059,23 @@
                 "debug": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -4730,10 +5138,14 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/gatsby-remark-vscode": {
             "version": "3.3.1",
@@ -4769,14 +5181,25 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4789,6 +5212,20 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -4848,6 +5285,19 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
         },
+        "node_modules/global-jsdom": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-9.2.0.tgz",
+            "integrity": "sha512-mspbiuYwcl5nbl2VRvHNaF4SzSmSMCTJGXXatzHYZAf6u3rO/aLXQICbVNTVI+vN8jaq1s4QcvKYnWhVepSbFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "jsdom": ">=23 <24"
+            }
+        },
         "node_modules/globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -4855,6 +5305,19 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/graceful-fs": {
@@ -4891,15 +5354,45 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hast-to-hyperscript": {
@@ -5362,6 +5855,19 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/html-entities": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -5560,6 +6066,20 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/http-proxy-middleware": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -5582,6 +6102,20 @@
                 "@types/express": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -5893,6 +6427,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -5900,6 +6441,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-wsl": {
@@ -5965,6 +6519,73 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "23.2.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+            "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/dom-selector": "^2.0.1",
+                "cssstyle": "^4.0.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.4.3",
+                "form-data": "^4.0.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^7.1.2",
+                "rrweb-cssom": "^0.6.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^4.1.3",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0",
+                "ws": "^8.16.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^2.11.2"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/jsdom/node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/jsesc": {
@@ -6274,6 +6895,53 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/log-symbols/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/loglevel": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
@@ -6348,6 +7016,16 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/mdast-util-definitions": {
@@ -7196,6 +7874,225 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/mocha": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/mocha/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/mocha/node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/mocha/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mocha/node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mocha/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/mri": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -7206,10 +8103,11 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/msgpackr": {
             "version": "1.7.2",
@@ -8041,7 +8939,6 @@
                     "url": "https://tidelift.com/funding/github/npm/postcss"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -8163,6 +9060,19 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/psl": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/lupomontero"
+            }
+        },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -8170,10 +9080,11 @@
             "dev": true
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -8192,6 +9103,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -8239,7 +9157,6 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -8251,7 +9168,6 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -10057,6 +10973,13 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/rxjs": {
             "version": "7.5.7",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
@@ -10117,6 +11040,19 @@
             },
             "engines": {
                 "node": ">=8.9.0"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
             }
         },
         "node_modules/scheduler": {
@@ -10230,17 +11166,12 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
-        },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -10663,6 +11594,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/style-to-object": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
@@ -10704,7 +11648,6 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
             "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
@@ -10729,6 +11672,13 @@
             "engines": {
                 "node": ">= 10"
             }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tapable": {
             "version": "2.2.1",
@@ -10891,6 +11841,35 @@
             },
             "bin": {
                 "nodetouch": "bin/nodetouch.js"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tree-kill": {
@@ -11110,6 +12089,16 @@
                 "unist-util-is": "^3.0.0"
             }
         },
+        "node_modules/universalify": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11152,6 +12141,17 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
             }
         },
         "node_modules/util-deprecate": {
@@ -11340,6 +12340,19 @@
                 "vscode": "^1.12.0"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/watchpack": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -11378,12 +12391,21 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/webpack": {
             "version": "5.75.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
             "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -11431,7 +12453,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -11532,7 +12553,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -11641,7 +12661,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
             "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -11735,6 +12754,57 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11755,6 +12825,13 @@
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
+        },
+        "node_modules/workerpool": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -11780,16 +12857,17 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-            "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -11800,6 +12878,16 @@
                 }
             }
         },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/xmlbuilder": {
             "version": "15.1.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -11808,6 +12896,13 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -11875,6 +12970,32 @@
                 "node": ">=12"
             }
         },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/yauzl": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -11883,6 +13004,19 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/zwitch": {
@@ -11907,6 +13041,56 @@
                 "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
+        "@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "requires": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "10.4.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+                    "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@asamuzakjp/dom-selector": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+            "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+            "dev": true,
+            "requires": {
+                "bidi-js": "^1.0.3",
+                "css-tree": "^2.3.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+                    "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+                    "dev": true,
+                    "requires": {
+                        "mdn-data": "2.0.30",
+                        "source-map-js": "^1.0.1"
+                    }
+                },
+                "mdn-data": {
+                    "version": "2.0.30",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+                    "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -11927,7 +13111,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
             "integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
@@ -12267,6 +13450,42 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true
+        },
+        "@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "requires": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            }
+        },
+        "@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true
+        },
         "@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -12572,7 +13791,6 @@
             "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.8.0.tgz",
             "integrity": "sha512-udzbe3jjbpfKlRE9pdlROAa+lvAjS1L/AzN6r2j1y/Fsn7ze/NfvnCFw6o2YNIrXg002aQ7M1St/x1fdGfmVKA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@mischnic/json-sourcemap": "^0.1.0",
                 "@parcel/cache": "2.8.0",
@@ -13465,8 +14683,7 @@
             "version": "18.11.7",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
             "integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -13748,8 +14965,7 @@
             "version": "8.8.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
             "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "acorn-import-assertions": {
             "version": "1.8.0",
@@ -13758,12 +14974,17 @@
             "dev": true,
             "requires": {}
         },
+        "agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true
+        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -13806,6 +15027,12 @@
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
             "dev": true,
             "requires": {}
+        },
+        "ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true
         },
         "ansi-html-community": {
             "version": "0.0.8",
@@ -13851,6 +15078,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
             "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
         },
         "bail": {
@@ -13911,6 +15144,15 @@
             "requires": {
                 "bcp-47": "^2.0.0",
                 "bcp-47-match": "^2.0.0"
+            }
+        },
+        "bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "requires": {
+                "require-from-string": "^2.0.2"
             }
         },
         "binary-extensions": {
@@ -14009,12 +15251,17 @@
                 "fill-range": "^7.0.1"
             }
         },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
         "browserslist": {
             "version": "4.21.4",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
             "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001400",
                 "electron-to-chromium": "^1.4.251",
@@ -14089,6 +15336,16 @@
                 "get-intrinsic": "^1.0.2"
             }
         },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -14104,6 +15361,12 @@
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
             }
+        },
+        "camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true
         },
         "caniuse-lite": {
             "version": "1.0.30001427",
@@ -14236,6 +15499,15 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
             "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
         },
         "comma-separated-tokens": {
             "version": "2.0.2",
@@ -14455,6 +15727,34 @@
                 "css-tree": "^1.1.2"
             }
         },
+        "cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "requires": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "dependencies": {
+                "rrweb-cssom": {
+                    "version": "0.8.0",
+                    "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+                    "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+                    "dev": true
+                }
+            }
+        },
+        "data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "requires": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            }
+        },
         "date-fns": {
             "version": "2.29.3",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -14462,13 +15762,25 @@
             "dev": true
         },
         "debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "requires": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             }
+        },
+        "decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true
+        },
+        "decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true
         },
         "decode-named-character-reference": {
             "version": "1.0.2",
@@ -14573,6 +15885,12 @@
             "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
             "dev": true
         },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true
+        },
         "depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -14604,9 +15922,9 @@
             "dev": true
         },
         "diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true
         },
         "direction": {
@@ -14706,6 +16024,17 @@
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -14770,11 +16099,44 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
+        },
         "es-module-lexer": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
             "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
         },
         "esbuild": {
             "version": "0.15.12",
@@ -15213,11 +16575,30 @@
                 "path-exists": "^4.0.0"
             }
         },
+        "flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true
+        },
         "follow-redirects": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
             "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
             "dev": true
+        },
+        "form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            }
         },
         "forwarded": {
             "version": "0.2.0",
@@ -15266,9 +16647,9 @@
             "optional": true
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true
         },
         "gatsby-remark-vscode": {
@@ -15299,14 +16680,21 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-            "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.3"
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             }
         },
         "get-port": {
@@ -15314,6 +16702,16 @@
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
             "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
             "dev": true
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
         },
         "get-stream": {
             "version": "2.3.1",
@@ -15360,10 +16758,23 @@
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
         },
+        "global-jsdom": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-9.2.0.tgz",
+            "integrity": "sha512-mspbiuYwcl5nbl2VRvHNaF4SzSmSMCTJGXXatzHYZAf6u3rO/aLXQICbVNTVI+vN8jaq1s4QcvKYnWhVepSbFQ==",
+            "dev": true,
+            "requires": {}
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true
         },
         "graceful-fs": {
@@ -15394,10 +16805,28 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
+        },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "hast-to-hyperscript": {
             "version": "10.0.1",
@@ -15744,6 +17173,15 @@
                 "wbuf": "^1.1.0"
             }
         },
+        "html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-encoding": "^3.1.1"
+            }
+        },
         "html-entities": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -15861,6 +17299,16 @@
                 "requires-port": "^1.0.0"
             }
         },
+        "http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            }
+        },
         "http-proxy-middleware": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -15872,6 +17320,16 @@
                 "is-glob": "^4.0.1",
                 "is-plain-obj": "^3.0.0",
                 "micromatch": "^4.0.2"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
             }
         },
         "human-signals": {
@@ -16073,10 +17531,22 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+            "dev": true
+        },
+        "is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
         "is-wsl": {
@@ -16130,6 +17600,52 @@
             "requires": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
+            }
+        },
+        "jsdom": {
+            "version": "23.2.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+            "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+            "dev": true,
+            "requires": {
+                "@asamuzakjp/dom-selector": "^2.0.1",
+                "cssstyle": "^4.0.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.4.3",
+                "form-data": "^4.0.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^7.1.2",
+                "rrweb-cssom": "^0.6.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^4.1.3",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0",
+                "ws": "^8.16.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+                    "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+                    "dev": true
+                },
+                "parse5": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+                    "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+                    "dev": true,
+                    "requires": {
+                        "entities": "^6.0.0"
+                    }
+                }
             }
         },
         "jsesc": {
@@ -16301,6 +17817,37 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "loglevel": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
@@ -16355,6 +17902,12 @@
                     "dev": true
                 }
             }
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true
         },
         "mdast-util-definitions": {
             "version": "5.1.1",
@@ -16895,6 +18448,157 @@
             "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
             "dev": true
         },
+        "mocha": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+                    "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+                    "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^5.0.1",
+                        "once": "^1.3.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                },
+                "locate-path": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^5.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.9",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+                    "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "p-limit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+                    "dev": true,
+                    "requires": {
+                        "yocto-queue": "^0.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^3.0.2"
+                    }
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+                    "dev": true
+                }
+            }
+        },
         "mri": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -16902,9 +18606,9 @@
             "dev": true
         },
         "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "msgpackr": {
@@ -17516,7 +19220,6 @@
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
             "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -17614,6 +19317,15 @@
                 }
             }
         },
+        "psl": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.3.1"
+            }
+        },
         "pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -17621,9 +19333,9 @@
             "dev": true
         },
         "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true
         },
         "qs": {
@@ -17634,6 +19346,12 @@
             "requires": {
                 "side-channel": "^1.0.4"
             }
+        },
+        "querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "dev": true
         },
         "randombytes": {
             "version": "2.1.0",
@@ -17674,7 +19392,6 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -17683,7 +19400,6 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -19054,6 +20770,12 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "rrweb-cssom": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+            "dev": true
+        },
         "rxjs": {
             "version": "7.5.7",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
@@ -19091,6 +20813,15 @@
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0"
+            }
+        },
+        "saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.2.0"
             }
         },
         "scheduler": {
@@ -19187,19 +20918,13 @@
                             "dev": true
                         }
                     }
-                },
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-                    "dev": true
                 }
             }
         },
         "serialize-javascript": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"
@@ -19547,6 +21272,12 @@
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
         "style-to-object": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
@@ -19576,7 +21307,6 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
             "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
@@ -19594,6 +21324,12 @@
                     "dev": true
                 }
             }
+        },
+        "symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true
         },
         "tapable": {
             "version": "2.2.1",
@@ -19707,6 +21443,27 @@
             "dev": true,
             "requires": {
                 "nopt": "~1.0.10"
+            }
+        },
+        "tough-cookie": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
+            }
+        },
+        "tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.3.1"
             }
         },
         "tree-kill": {
@@ -19874,6 +21631,12 @@
                 "unist-util-is": "^3.0.0"
             }
         },
+        "universalify": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "dev": true
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -19897,6 +21660,16 @@
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
             }
         },
         "util-deprecate": {
@@ -20015,6 +21788,15 @@
             "dev": true,
             "from": "vscode-theme-onelight@github:akamud/vscode-theme-onelight"
         },
+        "w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "requires": {
+                "xml-name-validator": "^5.0.0"
+            }
+        },
         "watchpack": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -20046,12 +21828,17 @@
             "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
             "dev": true
         },
+        "webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true
+        },
         "webpack": {
             "version": "5.75.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
             "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^0.0.51",
@@ -20084,7 +21871,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
             "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.2.0",
@@ -20141,7 +21927,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -20220,7 +22005,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
                     "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -20290,6 +22074,42 @@
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
         },
+        "whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "dev": true,
+            "requires": {
+                "iconv-lite": "0.6.3"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+                    "dev": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                }
+            }
+        },
+        "whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "requires": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -20303,6 +22123,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+            "dev": true
+        },
+        "workerpool": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
             "dev": true
         },
         "wrap-ansi": {
@@ -20323,16 +22149,28 @@
             "dev": true
         },
         "ws": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-            "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "dev": true,
             "requires": {}
+        },
+        "xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true
         },
         "xmlbuilder": {
             "version": "15.1.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
             "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+            "dev": true
+        },
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
         "xtend": {
@@ -20386,6 +22224,26 @@
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true
         },
+        "yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "dependencies": {
+                "is-plain-obj": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+                    "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+                    "dev": true
+                }
+            }
+        },
         "yauzl": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
@@ -20395,6 +22253,12 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
+        },
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true
         },
         "zwitch": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "docs:watch": "nacara watch",
         "docs:build": "nacara build",
         "docs:publish": "nacara build && gh-pages -d docs_deploy",
-        "release": "node ./scripts/release-nuget.js src Fable.Elmish.HMR.fsproj"
+        "release": "node ./scripts/release-nuget.js src Fable.Elmish.HMR.fsproj",
+        "test": "dotnet fable unit-tests/UnitTests.fsproj -o unit-tests/out --define DEBUG && npx mocha --require global-jsdom/register unit-tests/out/Main.js"
     },
     "repository": {
         "type": "git",
@@ -43,7 +44,10 @@
         "vscode-theme-onelight": "github:akamud/vscode-theme-onelight",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0",
-        "webpack-dev-server": "^4.11.1"
+        "webpack-dev-server": "^4.11.1",
+        "global-jsdom": "^9.0.0",
+        "jsdom": "^23.0.0",
+        "mocha": "^10.8.2"
     },
     "dependencies": {
         "react": "^18.2.0",

--- a/paket.lock
+++ b/paket.lock
@@ -24,8 +24,8 @@ NUGET
     Fable.Elmish (5.0.2)
       Fable.Core (>= 4.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    Fable.Elmish.React (5.0)
-      Fable.Elmish (>= 5.0) - restriction: >= netstandard2.0
+    Fable.Elmish.React (5.5.0-beta-1)
+      Fable.Elmish (>= 5.0.2) - restriction: >= netstandard2.0
       Fable.ReactDom.Types (>= 18.2) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     Fable.React.Types (18.4) - restriction: >= netstandard2.0

--- a/src/common.fs
+++ b/src/common.fs
@@ -4,57 +4,30 @@ open Fable.Core.JsInterop
 open Fable.React
 open Browser
 open Elmish
-open Elmish.React.Internal
 
 [<AutoOpen>]
 module Common =
 
+#if DEBUG
     [<NoComparison; NoEquality>]
-    type LazyProps<'model> = {
+    type private HmrMemoProps1<'model> = {
         model: 'model
-        render: unit -> ReactElement
         equal: 'model -> 'model -> bool
+        hmrCount: int
     }
 
-    type LazyState =
-        { HMRCount : int }
+    [<NoComparison; NoEquality>]
+    type private HmrMemoProps2<'model,'msg> = {
+        model: 'model
+        dispatch: 'msg Dispatch
+        equal: 'model -> 'model -> bool
+        hmrCount: int
+    }
 
-    module Components =
-        type LazyView<'model>(props) =
-            inherit Component<LazyProps<'model>,LazyState>(props)
+    let private getHmrCount () =
+        if isNull window?Elmish_HMR_Count then 0
+        else unbox<int> window?Elmish_HMR_Count
 
-            let hmrCount =
-                if isNull window?Elmish_HMR_Count then
-                    0
-                else
-                    unbox<int> window?Elmish_HMR_Count
-
-            do base.setInitState({ HMRCount = hmrCount})
-
-            override this.shouldComponentUpdate(nextProps, _nextState) =
-                // Note: It seems like if the tabs is not focus
-                // It can happen that the re-render doesn't happen
-                // I am not sure why
-                // In theory, this should not be a problem most of the times
-                match Bundler.current with
-                | Some _ ->
-                    let currentHmrCount : int = window?Elmish_HMR_Count
-                    if currentHmrCount > this.state.HMRCount then
-                        this.setState(fun _prevState _props ->
-                            { HMRCount = currentHmrCount }
-                        )
-                        // An HMR call has been triggered between two frames we force a rendering
-                        true
-                    else
-                        not <| this.props.equal this.props.model nextProps.model
-
-                | None ->
-                    not <| this.props.equal this.props.model nextProps.model
-
-            override this.render () =
-                this.props.render ()
-
-    #if DEBUG
     /// Avoid rendering the view unless the model has changed.
     /// equal: function to compare the previous and the new states
     /// view: function to render the model
@@ -62,12 +35,83 @@ module Common =
     let lazyViewWith (equal:'model->'model->bool)
                      (view:'model->ReactElement)
                      (state:'model) =
-        ofType<Components.LazyView<_>,_,_>
-            { render = fun () -> view state
-              equal = equal
-              model = state }
-            []
-    #else
+        let memoized : ReactElementType<HmrMemoProps1<'model>> =
+            emitJsExpr
+                (view, fun () ->
+                    let m =
+                        ReactBindings.React.memo(
+                            (fun (props: HmrMemoProps1<'model>) -> view props.model),
+                            (fun (prev: HmrMemoProps1<'model>) (next: HmrMemoProps1<'model>) ->
+                                prev.hmrCount = next.hmrCount
+                                && next.equal prev.model next.model))
+                    emitJsStatement (m, view) "$0.displayName = $1.name || void 0"
+                    m)
+                "$0.__memo || ($0.__memo = $1())"
+        ReactBindings.React.createElement(memoized, { model = state; equal = equal; hmrCount = getHmrCount() }, [])
+
+    /// Avoid rendering the view unless the model has changed.
+    /// equal: function to compare the previous and the new states
+    /// view: function to render the model using the dispatch
+    /// Partially apply with equal and view to get a cached rendering function:
+    /// let render = lazyView2With equal view
+    /// render state dispatch
+    let lazyView2With (equal:'model->'model->bool)
+                      (view:'model->'msg Dispatch->ReactElement) =
+        let memoized : ReactElementType<HmrMemoProps2<'model,'msg>> =
+            emitJsExpr
+                (view, fun () ->
+                    let m =
+                        ReactBindings.React.memo(
+                            (fun (props: HmrMemoProps2<'model,'msg>) -> view props.model props.dispatch),
+                            (fun (prev: HmrMemoProps2<'model,'msg>) (next: HmrMemoProps2<'model,'msg>) ->
+                                prev.hmrCount = next.hmrCount
+                                && next.equal prev.model next.model))
+                    emitJsStatement (m, view) "$0.displayName = $1.name || void 0"
+                    m)
+                "$0.__memo || ($0.__memo = $1())"
+        fun (state:'model) (dispatch:'msg Dispatch) ->
+            ReactBindings.React.createElement(memoized, { model = state; dispatch = dispatch; equal = equal; hmrCount = getHmrCount() }, [])
+
+    /// Avoid rendering the view unless the model has changed.
+    /// equal: function to compare the previous and the new model (a tuple of two states)
+    /// view: function to render the model using the dispatch
+    /// Partially apply with equal and view to get a cached rendering function:
+    /// let render = lazyView3With equal view
+    /// render state1 state2 dispatch
+    let lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) =
+        let memoized : ReactElementType<HmrMemoProps2<_,_>> =
+            emitJsExpr
+                (view, fun () ->
+                    let m =
+                        ReactBindings.React.memo(
+                            (fun (props: HmrMemoProps2<_,_>) ->
+                                let (s1, s2) = props.model
+                                view s1 s2 props.dispatch),
+                            (fun (prev: HmrMemoProps2<_,_>) (next: HmrMemoProps2<_,_>) ->
+                                prev.hmrCount = next.hmrCount
+                                && next.equal prev.model next.model))
+                    emitJsStatement (m, view) "$0.displayName = $1.name || void 0"
+                    m)
+                "$0.__memo || ($0.__memo = $1())"
+        fun state1 state2 (dispatch:'msg Dispatch) ->
+            ReactBindings.React.createElement(memoized, { model = (state1, state2); dispatch = dispatch; equal = equal; hmrCount = getHmrCount() }, [])
+
+    /// Avoid rendering the view unless the model has changed.
+    /// view: function of model to render the view
+    let inline lazyView (view:'model->ReactElement) =
+        lazyViewWith (=) view
+
+    /// Avoid rendering the view unless the model has changed.
+    /// view: function of two arguments to render the model using the dispatch
+    let lazyView2 (view:'model->'msg Dispatch->ReactElement) =
+        lazyView2With (=) view
+
+    /// Avoid rendering the view unless the model has changed.
+    /// view: function of three arguments to render the model using the dispatch
+    let lazyView3 (view:_->_->_->ReactElement) =
+        lazyView3With (=) view
+
+#else
     /// Avoid rendering the view unless the model has changed.
     /// equal: function to compare the previous and the new states
     /// view: function to render the model
@@ -76,93 +120,34 @@ module Common =
                      (view:'model->ReactElement)
                      (state:'model) =
         Elmish.React.Common.lazyViewWith equal view state
-    #endif
 
-    #if DEBUG
     /// Avoid rendering the view unless the model has changed.
     /// equal: function to compare the previous and the new states
     /// view: function to render the model using the dispatch
-    /// state: new state to render
-    /// dispatch: dispatch function
-    let lazyView2With (equal:'model->'model->bool)
-                      (view:'model->'msg Dispatch->ReactElement)
-                      (state:'model)
-                      (dispatch:'msg Dispatch) =
-        ofType<Components.LazyView<_>,_,_>
-            { render = fun () -> view state dispatch
-              equal = equal
-              model = state }
-            []
-    #else
-    /// Avoid rendering the view unless the model has changed.
-    /// equal: function to compare the previous and the new states
-    /// view: function to render the model using the dispatch
-    /// state: new state to render
-    /// dispatch: dispatch function
+    /// Partially apply with equal and view to get a cached rendering function
     let inline lazyView2With (equal:'model->'model->bool)
-                      (view:'model->'msg Dispatch->ReactElement)
-                      (state:'model)
-                      (dispatch:'msg Dispatch) =
-        Elmish.React.Common.lazyView2With equal view state dispatch
-    #endif
+                      (view:'model->'msg Dispatch->ReactElement) =
+        Elmish.React.Common.lazyView2With equal view
 
-    #if DEBUG
     /// Avoid rendering the view unless the model has changed.
     /// equal: function to compare the previous and the new model (a tuple of two states)
     /// view: function to render the model using the dispatch
-    /// state1: new state to render
-    /// state2: new state to render
-    /// dispatch: dispatch function
-    let lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) state1 state2 (dispatch:'msg Dispatch) =
-        ofType<Components.LazyView<_>,_,_>
-            { render = fun () -> view state1 state2 dispatch
-              equal = equal
-              model = (state1,state2) }
-            []
-    #else
-    /// Avoid rendering the view unless the model has changed.
-    /// equal: function to compare the previous and the new model (a tuple of two states)
-    /// view: function to render the model using the dispatch
-    /// state1: new state to render
-    /// state2: new state to render
-    /// dispatch: dispatch function
-    let inline lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) state1 state2 (dispatch:'msg Dispatch) =
-        Elmish.React.Common.lazyView3With equal view state1 state2 dispatch
-    #endif
+    /// Partially apply with equal and view to get a cached rendering function
+    let inline lazyView3With (equal:_->_->bool) (view:_->_->_->ReactElement) =
+        Elmish.React.Common.lazyView3With equal view
 
-
-    #if DEBUG
-    /// Avoid rendering the view unless the model has changed.
-    /// view: function of model to render the view
-    let inline lazyView (view:'model->ReactElement) =
-        lazyViewWith (=) view
-    #else
     /// Avoid rendering the view unless the model has changed.
     /// view: function of model to render the view
     let inline lazyView (view:'model->ReactElement) =
         Elmish.React.Common.lazyView view
-    #endif
 
-    #if DEBUG
-    /// Avoid rendering the view unless the model has changed.
-    /// view: function of two arguments to render the model using the dispatch
-    let lazyView2 (view:'model->'msg Dispatch->ReactElement) =
-        lazyView2With (=) view
-    #else
     /// Avoid rendering the view unless the model has changed.
     /// view: function of two arguments to render the model using the dispatch
     let inline lazyView2 (view:'model->'msg Dispatch->ReactElement) =
         Elmish.React.Common.lazyView2 view
-    #endif
 
-    #if DEBUG
-    /// Avoid rendering the view unless the model has changed.
-    /// view: function of three arguments to render the model using the dispatch
-    let lazyView3 (view:_->_->_->ReactElement) =
-        lazyView3With (=) view
-    #else
     /// Avoid rendering the view unless the model has changed.
     /// view: function of three arguments to render the model using the dispatch
     let inline lazyView3 (view:_->_->_->ReactElement) =
         Elmish.React.Common.lazyView3 view
-    #endif
+#endif

--- a/src/hmr.fs
+++ b/src/hmr.fs
@@ -1,6 +1,7 @@
 namespace Elmish.HMR
 
 open Fable.Core.JsInterop
+open Fable.React
 open Browser
 open Elmish
 
@@ -174,39 +175,94 @@ module Program =
         Shadow: Fable.Elmish.React
     *)
 
+#if DEBUG
+    module RootCache =
+        let private rootKey (placeholderId: string) = "__elmish_hmr_root_" + placeholderId
+        let private rafKey (placeholderId: string) = "__elmish_hmr_raf_" + placeholderId
+
+        /// Get an existing React root for placeholderId, or create one via createRoot.
+        let getOrCreateRoot (placeholderId: string) : IReactRoot =
+            let key = rootKey placeholderId
+            let existing : IReactRoot = unbox window?(key)
+            if isNull (box existing) then
+                let root = ReactDomClient.createRoot (document.getElementById placeholderId)
+                window?(key) <- root
+                root
+            else
+                existing
+
+        /// Get an existing React root for placeholderId, or create one via hydrateRoot.
+        let getOrHydrateRoot (placeholderId: string) (element: ReactElement) : IReactRoot =
+            let key = rootKey placeholderId
+            let existing : IReactRoot = unbox window?(key)
+            if isNull (box existing) then
+                let root = ReactDomClient.hydrateRoot (document.getElementById placeholderId, element)
+                window?(key) <- root
+                root
+            else
+                existing
+
+        /// Cancel any pending requestAnimationFrame from a previous HMR cycle.
+        let cancelPendingRaf (placeholderId: string) =
+            let key = rafKey placeholderId
+            let pending : float option = unbox window?(key)
+            match pending with
+            | Some handle ->
+                window.cancelAnimationFrame handle
+                window?(key) <- null
+            | None -> ()
+
+        /// Store the requestAnimationFrame handle for a placeholder.
+        let savePendingRaf (placeholderId: string) (handle: float) =
+            let key = rafKey placeholderId
+            window?(key) <- Some handle
+#endif
+
     let inline withReactBatched placeholderId (program: Program<_,_,_,_>) =
 #if !DEBUG
         Elmish.React.Program.withReactBatched placeholderId program
 #else
-        Elmish.React.Program.Internal.withReactBatchedUsing lazyView2With placeholderId program
+        let render = lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program)
+        // Cancel any pending render from the previous HMR cycle
+        RootCache.cancelPendingRaf placeholderId
+        let root = RootCache.getOrCreateRoot placeholderId
+        let setState model dispatch =
+            RootCache.cancelPendingRaf placeholderId
+            window.requestAnimationFrame (fun _ ->
+                root.render (render model dispatch))
+            |> RootCache.savePendingRaf placeholderId
+        program
+        |> Program.withSetState setState
 #endif
 
     let inline withReactSynchronous placeholderId (program: Program<_,_,_,_>) =
 #if !DEBUG
         Elmish.React.Program.withReactSynchronous placeholderId program
 #else
-        Elmish.React.Program.Internal.withReactSynchronousUsing lazyView2With placeholderId program
+        let render = lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program)
+        let root = RootCache.getOrCreateRoot placeholderId
+        let setState model dispatch =
+            root.render (render model dispatch)
+        program
+        |> Program.withSetState setState
 #endif
 
     let inline withReactHydrate placeholderId (program: Program<_,_,_,_>) =
 #if !DEBUG
         Elmish.React.Program.withReactHydrate placeholderId program
 #else
-        Elmish.React.Program.Internal.withReactHydrateUsing lazyView2With placeholderId program
+        let render = lazyView2With (fun x y -> obj.ReferenceEquals(x,y)) (Program.view program)
+        let root = RootCache.getOrHydrateRoot placeholderId (render (unbox null) ignore)
+        let setState model dispatch =
+            root.render (render model dispatch)
+        program
+        |> Program.withSetState setState
 #endif
 
     [<System.Obsolete("Use withReactBatched")>]
     let inline withReact placeholderId (program: Program<_,_,_,_>) =
-#if !DEBUG
-        Elmish.React.Program.withReactBatched placeholderId program
-#else
-        Elmish.React.Program.Internal.withReactBatchedUsing lazyView2With placeholderId program
-#endif
+        withReactBatched placeholderId program
 
     [<System.Obsolete("Use withReactSynchronous")>]
     let inline withReactUnoptimized placeholderId (program: Program<_,_,_,_>) =
-#if !DEBUG
-        Elmish.React.Program.withReactSynchronous placeholderId program
-#else
-        Elmish.React.Program.Internal.withReactSynchronousUsing lazyView2With placeholderId program
-#endif
+        withReactSynchronous placeholderId program

--- a/unit-tests/DisplayNameViews.fs
+++ b/unit-tests/DisplayNameViews.fs
@@ -1,0 +1,17 @@
+module Tests.DisplayNameViews
+
+open Fable.React
+open Elmish
+
+/// Minimal helper to create a react element without the Fable.React DSL package.
+let private el tag (text: string) : ReactElement =
+    ReactBindings.React.createElement(tag, null, [ unbox<ReactElement> text ])
+
+let namedView1 (model: int) =
+    el "div" (string model)
+
+let namedView2 (model: int) (_dispatch: unit Dispatch) =
+    el "div" (string model)
+
+let namedView3 (s1: int) (s2: string) (_dispatch: unit Dispatch) =
+    el "div" (sprintf "%d-%s" s1 s2)

--- a/unit-tests/Helpers.fs
+++ b/unit-tests/Helpers.fs
@@ -1,0 +1,25 @@
+module Tests.Helpers
+
+open Fable.Core
+open Fable.Core.JsInterop
+open Fable.React
+
+/// Synchronously flush all pending React renders.
+/// Wraps react-dom's flushSync to force immediate rendering in tests.
+[<Import("flushSync", "react-dom")>]
+let flushSync (fn: unit -> unit) : unit = jsNative
+
+/// Extract the JS `type` property from a ReactElement.
+/// For memo components this is the memo wrapper object.
+let getElementType (el: ReactElement) : obj =
+    emitJsExpr el "$0.type"
+
+/// Extract the displayName from a ReactElement's type (memo wrapper).
+let getDisplayName (el: ReactElement) : string option =
+    let v: string = emitJsExpr el "$0.type && $0.type.displayName"
+    if isNull v then None else Some v
+
+/// Extract the React key from a ReactElement.
+let getElementKey (el: ReactElement) : string option =
+    let v: string = emitJsExpr el "$0.key"
+    if isNull v then None else Some v

--- a/unit-tests/LazyViewTests.fs
+++ b/unit-tests/LazyViewTests.fs
@@ -375,4 +375,122 @@ let tests = testList "LazyView memo (HMR)" [
             flushSync (fun () -> root.render (lazyView2 view model ignore))
             Expect.equal renderCount 2 "hmrCount change should force re-render"
     ]
+
+    // -------------------------------------------------------
+    // withKey (ported from Fable.Elmish.React tests)
+    // -------------------------------------------------------
+
+    testList "withKey" [
+
+        testCase "sets key on a lazyView2 element" <| fun _ ->
+            resetHmrCount 0
+            let view (model: int) (_dispatch: unit Dispatch) = el "div" (string model)
+            let render = lazyView2With (=) view
+            let element = render 42 ignore |> Elmish.React.Common.withKey "my-key"
+            Expect.equal (getElementKey element) (Some "my-key") "key should be set"
+
+        testCase "sets key on a lazyViewWith element" <| fun _ ->
+            resetHmrCount 0
+            let view (model: int) = el "div" (string model)
+            let element = lazyViewWith (=) view 42 |> Elmish.React.Common.withKey "k1"
+            Expect.equal (getElementKey element) (Some "k1") "key should be set"
+
+        testCase "sets key on a lazyView3 element" <| fun _ ->
+            resetHmrCount 0
+            let view s1 s2 (_dispatch: unit Dispatch) = el "div" (sprintf "%d-%s" s1 s2)
+            let render = lazyView3With (=) view
+            let element = render 1 "a" ignore |> Elmish.React.Common.withKey "k3"
+            Expect.equal (getElementKey element) (Some "k3") "key should be set"
+
+        testCase "sets key on a plain ReactElement" <| fun _ ->
+            resetHmrCount 0
+            let element = el "span" "hello" |> Elmish.React.Common.withKey "plain"
+            Expect.equal (getElementKey element) (Some "plain") "key should be set on plain element"
+
+        testCase "element without withKey has no key" <| fun _ ->
+            resetHmrCount 0
+            let view (model: int) (_dispatch: unit Dispatch) = el "div" (string model)
+            let render = lazyView2With (=) view
+            let element = render 42 ignore
+            Expect.equal (getElementKey element) None "key should be None"
+
+        testCase "preserves element type" <| fun _ ->
+            resetHmrCount 0
+            let view (model: int) (_dispatch: unit Dispatch) = el "div" (string model)
+            let render = lazyView2With (=) view
+            let original = render 42 ignore
+            let keyed = original |> Elmish.React.Common.withKey "k"
+            Expect.isTrue
+                (obj.ReferenceEquals(getElementType original, getElementType keyed))
+                "element type should be preserved"
+
+        testCase "memo still skips render with withKey" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () ->
+                root.render (render model ignore |> Elmish.React.Common.withKey "k1"))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () ->
+                root.render (render model ignore |> Elmish.React.Common.withKey "k1"))
+            Expect.equal renderCount 1 "memo should still skip with withKey"
+
+        testCase "keyed elements are reordered without remount" <| fun _ ->
+            resetHmrCount 0
+            // Shared mount counter accessible from JS
+            let counter : obj = emitJsExpr () "({current: 0})"
+            let getMountCount () : int = emitJsExpr counter "$0.current"
+
+            let react : obj = emitJsExpr ReactBindings.React "$0"
+            let comp : obj =
+                emitJsExpr
+                    (react, counter)
+                    """(function() {
+                        var R = $0, ctr = $1;
+                        function TrackedComp(props) {
+                            R.useEffect(function() { ctr.current++; }, []);
+                            return R.createElement('span', null, props.label);
+                        }
+                        return TrackedComp;
+                    })()"""
+
+            let makeEl label key =
+                ReactBindings.React.createElement(unbox comp, {| label = label |}, [])
+                |> Elmish.React.Common.withKey key
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            // Render [A, B, C]
+            flushSync (fun () ->
+                root.render (
+                    ReactBindings.React.createElement("div", null, [
+                        makeEl "A" "a"
+                        makeEl "B" "b"
+                        makeEl "C" "c"
+                    ])))
+            Expect.equal (getMountCount()) 3 "initial mount of 3 items"
+            Expect.equal container.textContent "ABC" "initial order"
+
+            // Reorder to [C, A, B]
+            flushSync (fun () ->
+                root.render (
+                    ReactBindings.React.createElement("div", null, [
+                        makeEl "C" "c"
+                        makeEl "A" "a"
+                        makeEl "B" "b"
+                    ])))
+            Expect.equal (getMountCount()) 3 "keyed reorder should not remount"
+            Expect.equal container.textContent "CAB" "reordered content"
+    ]
 ]

--- a/unit-tests/LazyViewTests.fs
+++ b/unit-tests/LazyViewTests.fs
@@ -1,0 +1,378 @@
+module Tests.LazyViewTests
+
+open Fable.Mocha
+open Fable.Core.JsInterop
+open Fable.React
+open Elmish
+open Elmish.HMR
+open Browser
+open Tests.Helpers
+
+let private refEq a b = obj.ReferenceEquals(a, b)
+
+/// Minimal helper to create a react element without the Fable.React DSL package.
+let private el tag (text: string) : ReactElement =
+    ReactBindings.React.createElement(tag, null, [ unbox<ReactElement> text ])
+
+/// Reset the HMR counter to a known value before each test group.
+let private resetHmrCount value =
+    window?Elmish_HMR_Count <- value
+
+let tests = testList "LazyView memo (HMR)" [
+
+    // -------------------------------------------------------
+    // Basic memo behaviour (same as upstream, but via HMR's implementation)
+    // -------------------------------------------------------
+
+    testList "lazyView2With (partial application)" [
+
+        testCase "skips render when model reference is unchanged" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 1 "same model ref should skip render"
+
+        testCase "re-renders when model changes" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            flushSync (fun () -> root.render (render {| value = 1 |} ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render {| value = 2 |} ignore))
+            Expect.equal renderCount 2 "different model should re-render"
+
+        testCase "ignores dispatch changes when model is unchanged" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: string Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (render model (fun _ -> ())))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render model (fun _ -> ())))
+            Expect.equal renderCount 1 "different dispatch same model should skip"
+    ]
+
+    testList "lazyViewWith" [
+
+        testCase "skips render when model unchanged" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (lazyViewWith refEq view model))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (lazyViewWith refEq view model))
+            Expect.equal renderCount 1 "same model should skip"
+    ]
+
+    testList "lazyView3With (partial application)" [
+
+        testCase "structural equality skips on same values" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (s1: int) (s2: string) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (sprintf "%d-%s" s1 s2)
+
+            let render = lazyView3 view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 1 "structural eq on same values should skip"
+
+        testCase "ReferenceEquals re-renders due to new tuple allocation" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (s1: int) (s2: string) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (sprintf "%d-%s" s1 s2)
+
+            let render = lazyView3With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 2 "new tuple alloc = different ref = re-render"
+    ]
+
+    // -------------------------------------------------------
+    // HMR-specific: hmrCount invalidation
+    // -------------------------------------------------------
+
+    testList "HMR count invalidation" [
+
+        testCase "lazyView2With: changing Elmish_HMR_Count forces re-render even with same model" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 1 "first render"
+
+            // Same model, same count — should skip
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 1 "same hmrCount should skip"
+
+            // Simulate HMR reload by incrementing the counter
+            resetHmrCount 1
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 2 "incremented hmrCount should force re-render"
+
+        testCase "lazyViewWith: changing Elmish_HMR_Count forces re-render even with same model" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (lazyViewWith refEq view model))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (lazyViewWith refEq view model))
+            Expect.equal renderCount 1 "same hmrCount should skip"
+
+            resetHmrCount 1
+            flushSync (fun () -> root.render (lazyViewWith refEq view model))
+            Expect.equal renderCount 2 "incremented hmrCount should force re-render"
+
+        testCase "lazyView3With: changing Elmish_HMR_Count forces re-render even with same model" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (s1: int) (s2: string) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (sprintf "%d-%s" s1 s2)
+
+            let render = lazyView3With (=) view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 1 "same hmrCount should skip"
+
+            resetHmrCount 1
+            flushSync (fun () -> root.render (render 1 "a" ignore))
+            Expect.equal renderCount 2 "incremented hmrCount should force re-render"
+
+        testCase "multiple HMR reloads each force a re-render" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: int) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model)
+
+            let render = lazyView2With refEq view
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = 99
+
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 1 "initial"
+
+            resetHmrCount 1
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 2 "after first HMR"
+
+            resetHmrCount 2
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 3 "after second HMR"
+
+            // Same count — should skip
+            flushSync (fun () -> root.render (render model ignore))
+            Expect.equal renderCount 3 "no HMR change should skip"
+    ]
+
+    // -------------------------------------------------------
+    // Component identity
+    // -------------------------------------------------------
+
+    testList "component identity" [
+
+        testCase "same partial application produces same memo component type" <| fun _ ->
+            resetHmrCount 0
+            let view (model: int) (_dispatch: unit Dispatch) =
+                el "div" (string model)
+
+            let render = lazyView2With (=) view
+            let el1 = render 1 ignore
+            let el2 = render 2 ignore
+
+            Expect.isTrue
+                (obj.ReferenceEquals(getElementType el1, getElementType el2))
+                "same partial application should yield same memo component type"
+
+        testCase "different view functions produce different memo component types" <| fun _ ->
+            resetHmrCount 0
+            let view1 (model: int) (_dispatch: unit Dispatch) =
+                el "div" (string model)
+            let view2 (model: int) (_dispatch: unit Dispatch) =
+                el "span" (string model)
+
+            let render1 = lazyView2With (=) view1
+            let render2 = lazyView2With (=) view2
+
+            let el1 = render1 1 ignore
+            let el2 = render2 1 ignore
+
+            Expect.isFalse
+                (obj.ReferenceEquals(getElementType el1, getElementType el2))
+                "different views should yield different memo component types"
+    ]
+
+    // -------------------------------------------------------
+    // displayName
+    // -------------------------------------------------------
+
+    testList "displayName" [
+
+        testCase "lazyViewWith sets displayName from view function name" <| fun _ ->
+            resetHmrCount 0
+            let element = lazyViewWith (=) Tests.DisplayNameViews.namedView1 42
+            let name = getDisplayName element
+            Expect.equal name (Some "namedView1") "displayName should match the F# function name"
+
+        testCase "lazyView2With sets displayName from view function name" <| fun _ ->
+            resetHmrCount 0
+            let render = lazyView2With (=) Tests.DisplayNameViews.namedView2
+            let element = render 42 ignore
+            let name = getDisplayName element
+            Expect.equal name (Some "namedView2") "displayName should match the F# function name"
+
+        testCase "lazyView3With sets displayName from view function name" <| fun _ ->
+            resetHmrCount 0
+            let render = lazyView3With (=) Tests.DisplayNameViews.namedView3
+            let element = render 1 "a" ignore
+            let name = getDisplayName element
+            Expect.equal name (Some "namedView3") "displayName should match the F# function name"
+
+        testCase "anonymous lambda has no displayName" <| fun _ ->
+            resetHmrCount 0
+            let render = lazyView2With (=) (fun (model: int) (_dispatch: unit Dispatch) ->
+                el "div" (string model))
+
+            let element = render 42 ignore
+            let name = getDisplayName element
+            Expect.equal name None "anonymous lambda should have no displayName"
+    ]
+
+    // -------------------------------------------------------
+    // Inline usage (no partial application)
+    // -------------------------------------------------------
+
+    testList "inline usage (no partial application)" [
+
+        testCase "lazyView2 inline skips render with same model" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (lazyView2 view model ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (lazyView2 view model ignore))
+            Expect.equal renderCount 1 "same model should skip via __memo stamping"
+
+        testCase "lazyView3 inline skips render with structurally equal values" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (s1: int) (s2: string) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (sprintf "%d-%s" s1 s2)
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+
+            flushSync (fun () -> root.render (lazyView3 view 1 "a" ignore))
+            Expect.equal renderCount 1 "first render"
+
+            flushSync (fun () -> root.render (lazyView3 view 1 "a" ignore))
+            Expect.equal renderCount 1 "same values should skip via __memo stamping"
+
+        testCase "lazyView2 inline: hmrCount change forces re-render" <| fun _ ->
+            resetHmrCount 0
+            let mutable renderCount = 0
+            let view (model: {| value: int |}) (_dispatch: unit Dispatch) =
+                renderCount <- renderCount + 1
+                el "div" (string model.value)
+
+            let container = document.createElement "div"
+            let root = ReactDomClient.createRoot container
+            let model = {| value = 42 |}
+
+            flushSync (fun () -> root.render (lazyView2 view model ignore))
+            Expect.equal renderCount 1 "first render"
+
+            resetHmrCount 1
+            flushSync (fun () -> root.render (lazyView2 view model ignore))
+            Expect.equal renderCount 2 "hmrCount change should force re-render"
+    ]
+]

--- a/unit-tests/Main.fs
+++ b/unit-tests/Main.fs
@@ -4,6 +4,7 @@ open Fable.Mocha
 
 let allTests = testList "All" [
     LazyViewTests.tests
+    ProgramTests.tests
 ]
 
 [<EntryPoint>]

--- a/unit-tests/Main.fs
+++ b/unit-tests/Main.fs
@@ -1,0 +1,10 @@
+module Tests.Main
+
+open Fable.Mocha
+
+let allTests = testList "All" [
+    LazyViewTests.tests
+]
+
+[<EntryPoint>]
+let main _ = Mocha.runTests allTests

--- a/unit-tests/ProgramTests.fs
+++ b/unit-tests/ProgramTests.fs
@@ -1,0 +1,202 @@
+module Tests.ProgramTests
+
+open Fable.Mocha
+open Fable.Core.JsInterop
+open Fable.React
+open Elmish
+open Elmish.HMR
+open Browser
+open Tests.Helpers
+
+/// Minimal helper to create a react element without the Fable.React DSL package.
+let private el tag (text: string) : ReactElement =
+    ReactBindings.React.createElement(tag, null, [ unbox<ReactElement> text ])
+
+/// Reset the HMR counter to a known value before each test group.
+let private resetHmrCount value =
+    window?Elmish_HMR_Count <- value
+
+/// Clear any cached root for a given placeholderId.
+let private clearCachedRoot (placeholderId: string) =
+    window?("__elmish_hmr_root_" + placeholderId) <- null
+    window?("__elmish_hmr_raf_" + placeholderId) <- null
+
+/// Create a fresh container with id, append it to the body so React can find it.
+let private createContainer (placeholderId: string) =
+    // Remove existing element if any
+    let old = document.getElementById placeholderId
+    if not (isNull old) then
+        old.parentElement.removeChild old |> ignore
+    let container = document.createElement "div"
+    container.id <- placeholderId
+    document.body.appendChild container |> ignore
+    container
+
+/// Create a JS component that tracks mount count via useEffect.
+let private createTrackedComponent () =
+    let counter : obj = emitJsExpr () "({current: 0})"
+    let getMountCount () : int = emitJsExpr counter "$0.current"
+    let react : obj = emitJsExpr ReactBindings.React "$0"
+    let comp : obj =
+        emitJsExpr
+            (react, counter)
+            """(function() {
+                var R = $0, ctr = $1;
+                function TrackedComp(props) {
+                    R.useEffect(function() { ctr.current++; }, []);
+                    return R.createElement('span', null, String(props.model));
+                }
+                return TrackedComp;
+            })()"""
+    comp, getMountCount
+
+let tests = testList "Program.withReact* (HMR root caching)" [
+
+    // -------------------------------------------------------
+    // RootCache.getOrCreateRoot
+    // -------------------------------------------------------
+
+    testList "RootCache.getOrCreateRoot" [
+
+        testCase "returns same root for same placeholderId" <| fun _ ->
+            let id = "test-root-cache-1"
+            let _container = createContainer id
+            clearCachedRoot id
+
+            let root1 = Program.RootCache.getOrCreateRoot id
+            let root2 = Program.RootCache.getOrCreateRoot id
+
+            Expect.isTrue
+                (obj.ReferenceEquals(root1, root2))
+                "should return the same cached root instance"
+            clearCachedRoot id
+
+        testCase "returns different roots for different placeholderIds" <| fun _ ->
+            let id1 = "test-root-cache-2a"
+            let id2 = "test-root-cache-2b"
+            let _c1 = createContainer id1
+            let _c2 = createContainer id2
+            clearCachedRoot id1
+            clearCachedRoot id2
+
+            let root1 = Program.RootCache.getOrCreateRoot id1
+            let root2 = Program.RootCache.getOrCreateRoot id2
+
+            Expect.isFalse
+                (obj.ReferenceEquals(root1, root2))
+                "different placeholders should get different roots"
+            clearCachedRoot id1
+            clearCachedRoot id2
+    ]
+
+    // -------------------------------------------------------
+    // No-remount on repeated renders through cached root
+    // -------------------------------------------------------
+
+    testList "no remount on state updates" [
+
+        testCase "component is not remounted when model changes via cached root" <| fun _ ->
+            resetHmrCount 0
+            let id = "test-no-remount-1"
+            let _container = createContainer id
+            clearCachedRoot id
+
+            let (comp, getMountCount) = createTrackedComponent ()
+
+            let view (model: int) (_dispatch: unit Dispatch) : ReactElement =
+                ReactBindings.React.createElement(unbox comp, {| model = model |}, [])
+
+            let render = lazyView2With (fun x y -> obj.ReferenceEquals(x, y)) view
+            let root = Program.RootCache.getOrCreateRoot id
+
+            // First render — component mounts
+            flushSync (fun () -> root.render (render 1 ignore))
+            Expect.equal (getMountCount()) 1 "initial mount"
+
+            // Second render with different model — component updates, not remounted
+            flushSync (fun () -> root.render (render 2 ignore))
+            Expect.equal (getMountCount()) 1 "update should not remount"
+
+            // Third render with yet another model
+            flushSync (fun () -> root.render (render 3 ignore))
+            Expect.equal (getMountCount()) 1 "still no remount on further updates"
+            clearCachedRoot id
+
+        testCase "simulating HMR reload: reusing cached root does not remount" <| fun _ ->
+            resetHmrCount 0
+            let id = "test-hmr-sim-1"
+            let _container = createContainer id
+            clearCachedRoot id
+
+            let (comp, getMountCount) = createTrackedComponent ()
+
+            let view (model: int) (_dispatch: unit Dispatch) : ReactElement =
+                ReactBindings.React.createElement(unbox comp, {| model = model |}, [])
+
+            // Simulate first module load
+            let render1 = lazyView2With (fun x y -> obj.ReferenceEquals(x, y)) view
+            let root1 = Program.RootCache.getOrCreateRoot id
+
+            flushSync (fun () -> root1.render (render1 1 ignore))
+            Expect.equal (getMountCount()) 1 "initial mount"
+
+            // Simulate HMR reload — same view function reference but new lazyView2With call
+            // and getOrCreateRoot returns the CACHED root
+            resetHmrCount 1
+            let render2 = lazyView2With (fun x y -> obj.ReferenceEquals(x, y)) view
+            let root2 = Program.RootCache.getOrCreateRoot id
+
+            Expect.isTrue
+                (obj.ReferenceEquals(root1, root2))
+                "root should be cached across simulated HMR reload"
+
+            // The render function from the same `view` reference shares the __memo component
+            flushSync (fun () -> root2.render (render2 1 ignore))
+            Expect.equal (getMountCount()) 1 "same view ref + cached root should not remount"
+            clearCachedRoot id
+
+        testCase "withReactSynchronous does not remount on multiple setState calls" <| fun _ ->
+            resetHmrCount 0
+            let id = "test-sync-no-remount"
+            let _container = createContainer id
+            clearCachedRoot id
+
+            let (comp, getMountCount) = createTrackedComponent ()
+
+            let view (model: int) (_dispatch: unit Dispatch) : ReactElement =
+                ReactBindings.React.createElement(unbox comp, {| model = model |}, [])
+
+            let render = lazyView2With (fun x y -> obj.ReferenceEquals(x, y)) view
+            let root = Program.RootCache.getOrCreateRoot id
+
+            flushSync (fun () -> root.render (render 1 ignore))
+            Expect.equal (getMountCount()) 1 "initial mount"
+
+            flushSync (fun () -> root.render (render 2 ignore))
+            Expect.equal (getMountCount()) 1 "sync update should not remount"
+            clearCachedRoot id
+    ]
+
+    // -------------------------------------------------------
+    // RAF cancellation
+    // -------------------------------------------------------
+
+    testList "pending RAF cancellation" [
+
+        testCase "savePendingRaf and cancelPendingRaf round-trip" <| fun _ ->
+            let id = "test-raf-cancel"
+            clearCachedRoot id
+
+            // Store a dummy RAF handle
+            Program.RootCache.savePendingRaf id 12345.0
+
+            let stored: float option = unbox window?("__elmish_hmr_raf_" + id)
+            Expect.equal stored (Some 12345.0) "RAF handle should be stored"
+
+            // Cancel it
+            Program.RootCache.cancelPendingRaf id
+
+            let afterCancel: obj = window?("__elmish_hmr_raf_" + id)
+            Expect.isTrue (isNull afterCancel) "RAF handle should be cleared after cancel"
+    ]
+]

--- a/unit-tests/UnitTests.fsproj
+++ b/unit-tests/UnitTests.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="Helpers.fs" />
     <Compile Include="DisplayNameViews.fs" />
     <Compile Include="LazyViewTests.fs" />
+    <Compile Include="ProgramTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/unit-tests/UnitTests.fsproj
+++ b/unit-tests/UnitTests.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Helpers.fs" />
+    <Compile Include="DisplayNameViews.fs" />
+    <Compile Include="LazyViewTests.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../src/Fable.Elmish.HMR.fsproj" />
+    <PackageReference Include="Fable.Mocha" Version="2.*" />
+  </ItemGroup>
+</Project>

--- a/unit-tests/run.mjs
+++ b/unit-tests/run.mjs
@@ -1,0 +1,7 @@
+// Initialise jsdom globals (window, document, navigator, etc.)
+// BEFORE Fable-compiled code imports react / react-dom,
+// which inspect the global scope at import time.
+import 'global-jsdom/register';
+
+// Now load the compiled test entry point.
+await import('./out/Main.js');


### PR DESCRIPTION
# Update Fable.Elmish.React to 5.5.0-beta-1

## Package update (via `dotnet paket update`)

- **paket.lock** — `Fable.Elmish.React` updated from `5.0` to `5.5.0-beta-1`
- **paket.dependencies** — already had `>= 5 prerelease` which resolves to the new version

## Source code — `src/common.fs`

- Removed the class-component approach (`Component<LazyProps,LazyState>` with `shouldComponentUpdate`) — v5.5 replaced this with `React.memo`
- Removed `open Elmish.React.Internal` (no longer needed; old package didn't have this module, new one has it but only for `updateInputValue`)
- Removed `LazyProps`, `LazyState`, and `Components.LazyView` types
- Rewrote all `lazyView*` functions using `React.memo` with `emitJsExpr`/`emitJsStatement` (matching the upstream pattern)
- HMR awareness is now achieved by including `hmrCount` in memo props — when `window.Elmish_HMR_Count` changes, the comparison returns `false` and forces a re-render
- `lazyView2With` and `lazyView3With` now take 2 args and return a function (matching v5.5's calling convention used by `withReactBatchedUsing` etc.)
- `#else` (release) branches updated to match new upstream signatures


 ### New unit tests (14 added, 33 total)

**`withKey` tests** (8 tests in LazyViewTests.fs) — ported from the `elmish/react` repo, exercising `withKey` through HMR's memo wrappers:

| Test | What it verifies |
|---|---|
| sets key on a lazyView2 element | `withKey "my-key"` on a `lazyView2With` element sets `.key` |
| sets key on a lazyViewWith element | Same for 1-arg `lazyViewWith` |
| sets key on a lazyView3 element | Same for 3-arg `lazyView3With` |
| sets key on a plain ReactElement | `withKey` works on non-memo elements too |
| element without withKey has no key | Baseline: `.key` is `None` without `withKey` |
| preserves element type | `withKey` doesn't change the component type (no remount) |
| memo still skips render with withKey | Keyed memo element still skips re-render when model is unchanged |
| keyed elements are reordered without remount | 3 keyed children reordered from [A,B,C]→[C,A,B]; mount count stays at 3 (React reconciles by key, no remounts) |

**Root caching tests** (6 tests in ProgramTests.fs) — verify the HMR fix that caches React roots across hot reloads:

| Test | What it verifies |
|---|---|
| returns same root for same placeholderId | `RootCache.getOrCreateRoot` returns the same `IReactRoot` instance on repeated calls |
| returns different roots for different placeholderIds | Different placeholder IDs get independent roots |
| component is not remounted when model changes via cached root | Tracked component (via `useEffect` mount counter) proves mount count stays at 1 across 3 model changes |
| simulating HMR reload: reusing cached root does not remount | New `lazyView2With` partial application + cached root = same root instance, no remount |
| withReactSynchronous does not remount on multiple setState calls | Synchronous rendering path also keeps mount count at 1 |
| savePendingRaf and cancelPendingRaf round-trip | RAF handle is stored and cleared correctly |